### PR TITLE
Kv config builder

### DIFF
--- a/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
+++ b/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.0.1</Version>
-    <PackageReleaseNotes>switched key vault section manager to MS provided one</PackageReleaseNotes>
+    <Version>3.0.0</Version>
+    <PackageReleaseNotes>
+      Changed the way the config builder is built:
+      - Made all appsettings files optional
+      - Introduced final KeyVault environment variable
+    </PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     

--- a/src/Eshopworld.DevOps/EswDevOpsSdk.cs
+++ b/src/Eshopworld.DevOps/EswDevOpsSdk.cs
@@ -44,8 +44,6 @@ namespace Eshopworld.DevOps
         /// <summary>
         /// Builds the <see cref="ConfigurationBuilder"/> and retrieves all main config sections from the resulting
         ///     configuration.
-        /// Under a test run, the release definition will rename the environment ex: appsettings.CI.json file for the target environment (CI)
-        ///     to appsettings.TEST.json, so useTest will effectively load the right file.
         /// </summary>
         /// <param name="basePath">The base path to use when looking for the JSON settings files.</param>
         /// <param name="environment">The name of the environment to scan for environmental configuration, null to skip.</param>
@@ -54,9 +52,9 @@ namespace Eshopworld.DevOps
         /// The configuration flow is:
         ///     #1 Get the default appsettings.json
         ///     #2 Get the environmental appsettings.{ENV}.json
-        ///     #3 If it's a test, load the [optional] appsettings.TEST.json
+        ///     #3 Get the environment variables - Usually the KeyVault URI is injected here
         ///     #4 Try to get the Vault setting from configuration
-        ///     #5 If Vault details are present, load configuration from the target vault
+        ///     #5 If Vault details are present, load configuration from the target vault using managed identities
         /// </remarks>
         public static IConfigurationRoot BuildConfiguration(string basePath, string environment = null)
         {

--- a/src/Tests/Eshopworld.DevOps.Tests/DeploymentRegionTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/DeploymentRegionTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 public class DeploymentRegionTests
 {
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void WestEurope_StringChecks()
     {
         DeploymentRegion we = DeploymentRegion.WestEurope;
@@ -16,7 +16,7 @@ public class DeploymentRegionTests
         we.ToRegionCode().Should().Be("WE");
     }
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void EastUS_StringChecks()
     {
         DeploymentRegion eus = DeploymentRegion.EastUS;
@@ -24,7 +24,7 @@ public class DeploymentRegionTests
         eus.ToRegionCode().Should().Be("EUS");
     }
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void UnrecognizedValue()
     {
         DeploymentRegion sut = (DeploymentRegion) 666;
@@ -32,7 +32,7 @@ public class DeploymentRegionTests
         Assert.Throws<ArgumentException>(() => sut.ToRegionCode());
     }
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void EnsureAllItemsHaveDescriptor()
     {
         foreach (var field in typeof(DeploymentRegion).GetFields().Where(fi => !fi.IsSpecialName))

--- a/src/Tests/Eshopworld.DevOps.Tests/DeploymentRegionTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/DeploymentRegionTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 public class DeploymentRegionTests
 {
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void WestEurope_StringChecks()
     {
         DeploymentRegion we = DeploymentRegion.WestEurope;
@@ -16,7 +16,7 @@ public class DeploymentRegionTests
         we.ToRegionCode().Should().Be("WE");
     }
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void EastUS_StringChecks()
     {
         DeploymentRegion eus = DeploymentRegion.EastUS;
@@ -24,7 +24,7 @@ public class DeploymentRegionTests
         eus.ToRegionCode().Should().Be("EUS");
     }
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void UnrecognizedValue()
     {
         DeploymentRegion sut = (DeploymentRegion) 666;
@@ -32,7 +32,7 @@ public class DeploymentRegionTests
         Assert.Throws<ArgumentException>(() => sut.ToRegionCode());
     }
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void EnsureAllItemsHaveDescriptor()
     {
         foreach (var field in typeof(DeploymentRegion).GetFields().Where(fi => !fi.IsSpecialName))

--- a/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
@@ -11,17 +11,17 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 public class EswDevOpsSdkTests
 {
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void BuildConfiguration_ReadFromCoreAppSettings()
     {
-        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, "ENV1"); //process level is fine here
+        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, "ENV1", EnvironmentVariableTarget.Process); //process level is fine here
         var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory);
 
         sut["KeyRootAppSettings"].Should().BeEquivalentTo("AppSettingsValue");
     }
 
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void BuildConfiguration_NonTestMode()
 
     {
@@ -31,7 +31,7 @@ public class EswDevOpsSdkTests
     }
 
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void BuildConfiguration_ReadFromEnvironmentalAppSettings()
 
     {
@@ -41,7 +41,7 @@ public class EswDevOpsSdkTests
     }
 
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void BuildConfiguration_ReadFromEnvironmentalVariable()
     {
         var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory);
@@ -58,14 +58,14 @@ public class EswDevOpsSdkTests
 
     private const string SierraIntegration = "si";
 
-    [Theory, IsDev]
+    [Theory, IsUnit]
     [InlineData("CI", DeploymentEnvironment.CI)]
     [InlineData("PREP", DeploymentEnvironment.Prep)]
     [InlineData("pRep", DeploymentEnvironment.Prep)]
     public void GeEnvironmentTest(string envValue, DeploymentEnvironment env)
     {
         var prevEnv = Environment.GetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable);
-        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, envValue);
+        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, envValue, EnvironmentVariableTarget.Process);
         try
         {
             var currentEnvironment = EswDevOpsSdk.GetEnvironment();
@@ -73,11 +73,11 @@ public class EswDevOpsSdkTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, prevEnv);
+            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, prevEnv, EnvironmentVariableTarget.Process);
         }
     }
 
-    [Theory, IsDev]
+    [Theory, IsUnit]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
@@ -85,7 +85,7 @@ public class EswDevOpsSdkTests
     public void GeEnvironmentFailsTest(string env)
     {
         var prevEnv = Environment.GetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable);
-        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, env);
+        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, env, EnvironmentVariableTarget.Process);
         try
         {
             Action func = () => EswDevOpsSdk.GetEnvironment();
@@ -93,11 +93,11 @@ public class EswDevOpsSdkTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, prevEnv);
+            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, prevEnv, EnvironmentVariableTarget.Process);
         }
     }
 
-    [Theory, IsDev]
+    [Theory, IsUnit]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.Test, DeploymentEnvironment.Test)]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.CI, DeploymentEnvironment.CI)]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.Sand, DeploymentEnvironment.Sand)]
@@ -111,7 +111,7 @@ public class EswDevOpsSdkTests
     [InlineData(DeploymentEnvironment.Sand, DeploymentEnvironment.Sand, SierraIntegration)]
     public void GetDeploymentSubscriptionIdTest(DeploymentEnvironment environmentName, DeploymentEnvironment deploymentEnvironmentName, object resultEnvironmentSubscription)
     {
-        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, environmentName.ToString());
+        Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, environmentName.ToString(), EnvironmentVariableTarget.Process);
         var expectedSubscriptionId = resultEnvironmentSubscription as string == SierraIntegration
             ? EswDevOpsSdk.SierraIntegrationSubscriptionId
             : EswDevOpsSdk.GetSubscriptionId(deploymentEnvironmentName);
@@ -121,19 +121,19 @@ public class EswDevOpsSdkTests
         subscriptionId.Should().Be(expectedSubscriptionId);
     }
 
-    [Fact, IsDev]
+    [Fact, IsUnit]
     public void GetSubscriptionId_works_for_known_environments()
     {
         var environmentNames = Enum.GetNames(typeof(DeploymentEnvironment));
         foreach (var environmentName in environmentNames)
         {
-            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, environmentName);
+            Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, environmentName, EnvironmentVariableTarget.Process);
             var subscriptionId = EswDevOpsSdk.GetSubscriptionId();
             subscriptionId.Should().NotBeNullOrEmpty();
         }
     }
 
-    [Theory, IsDev]
+    [Theory, IsUnit]
     [InlineData(DeploymentEnvironment.CI, DeploymentRegion.WestEurope, new[] { DeploymentRegion.WestEurope })]
     [InlineData(DeploymentEnvironment.Prod, DeploymentRegion.WestEurope, new[] { DeploymentRegion.WestEurope, DeploymentRegion.EastUS })]
     [InlineData(DeploymentEnvironment.Prod, DeploymentRegion.EastUS, new[] { DeploymentRegion.EastUS, DeploymentRegion.WestEurope })]

--- a/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 public class EswDevOpsSdkTests
 {
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void BuildConfiguration_ReadFromCoreAppSettings()
     {
         Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, "ENV1", EnvironmentVariableTarget.Process); //process level is fine here
@@ -21,7 +21,7 @@ public class EswDevOpsSdkTests
     }
 
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void BuildConfiguration_NonTestMode()
 
     {
@@ -31,7 +31,7 @@ public class EswDevOpsSdkTests
     }
 
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void BuildConfiguration_ReadFromEnvironmentalAppSettings()
 
     {
@@ -41,7 +41,7 @@ public class EswDevOpsSdkTests
     }
 
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void BuildConfiguration_ReadFromEnvironmentalVariable()
     {
         var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory);
@@ -58,7 +58,7 @@ public class EswDevOpsSdkTests
 
     private const string SierraIntegration = "si";
 
-    [Theory, IsUnit]
+    [Theory, IsLayer0]
     [InlineData("CI", DeploymentEnvironment.CI)]
     [InlineData("PREP", DeploymentEnvironment.Prep)]
     [InlineData("pRep", DeploymentEnvironment.Prep)]
@@ -77,7 +77,7 @@ public class EswDevOpsSdkTests
         }
     }
 
-    [Theory, IsUnit]
+    [Theory, IsLayer0]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
@@ -97,7 +97,7 @@ public class EswDevOpsSdkTests
         }
     }
 
-    [Theory, IsUnit]
+    [Theory, IsLayer0]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.Test, DeploymentEnvironment.Test)]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.CI, DeploymentEnvironment.CI)]
     [InlineData(DeploymentEnvironment.Prod, DeploymentEnvironment.Sand, DeploymentEnvironment.Sand)]
@@ -121,7 +121,7 @@ public class EswDevOpsSdkTests
         subscriptionId.Should().Be(expectedSubscriptionId);
     }
 
-    [Fact, IsUnit]
+    [Fact, IsLayer0]
     public void GetSubscriptionId_works_for_known_environments()
     {
         var environmentNames = Enum.GetNames(typeof(DeploymentEnvironment));
@@ -133,7 +133,7 @@ public class EswDevOpsSdkTests
         }
     }
 
-    [Theory, IsUnit]
+    [Theory, IsLayer0]
     [InlineData(DeploymentEnvironment.CI, DeploymentRegion.WestEurope, new[] { DeploymentRegion.WestEurope })]
     [InlineData(DeploymentEnvironment.Prod, DeploymentRegion.WestEurope, new[] { DeploymentRegion.WestEurope, DeploymentRegion.EastUS })]
     [InlineData(DeploymentEnvironment.Prod, DeploymentRegion.EastUS, new[] { DeploymentRegion.EastUS, DeploymentRegion.WestEurope })]

--- a/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/EswDevOpsSdkTests.cs
@@ -49,17 +49,10 @@ public class EswDevOpsSdkTests
         sut["PATH"].Should().NotBeNullOrEmpty();
     }
 
-    [Fact, IsDev]
-    public void BuildConfiguration_TestMode()
-    {
-        var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory, useTest: true);
-        sut["KeyTestAppSettings"].Should().Be("IntegrationAppSettingsValue");
-    }
-
     [Fact, IsLayer1]
     public void BuildConfiguration_MSIAuthenticationTest()
     {
-        var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory, "CI", true);
+        var sut = EswDevOpsSdk.BuildConfiguration(AssemblyDirectory, "CI");
         sut["keyVaultItem"].Should().Be("keyVaultItemValue");
     }
 
@@ -131,7 +124,7 @@ public class EswDevOpsSdkTests
     [Fact, IsDev]
     public void GetSubscriptionId_works_for_known_environments()
     {
-        var environmentNames = typeof(DeploymentEnvironment).GetFields().Select(x => (string)x.GetValue(null));
+        var environmentNames = Enum.GetNames(typeof(DeploymentEnvironment));
         foreach (var environmentName in environmentNames)
         {
             Environment.SetEnvironmentVariable(EswDevOpsSdk.EnvironmentEnvVariable, environmentName);

--- a/src/Tests/Eshopworld.DevOps.Tests/appSettings.CI.json
+++ b/src/Tests/Eshopworld.DevOps.Tests/appSettings.CI.json
@@ -1,3 +1,3 @@
 ﻿{
-  "KeyVaultUrl": "https://devopsflex-tests.vault.azure.net/"
+  "KEYVAULT_URL": "https://devopsflex-tests.vault.azure.net/"
 }


### PR DESCRIPTION
Changed the way the config builder is built:
- Made all appsettings files optional, to support fabric services and actors where we only read environment variables
- Changed the KV environment variable name to the final value

Also moved most `IsDev` tests to `IsUnit` by setting environment variables at the process level.