### PR TITLE
#61695 Use new Azure SDK

### DIFF
--- a/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
+++ b/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>5.0.1</Version>
-    <PackageReleaseNotes>Downgrade of Microsoft.Extensions.Configuration.AzureKeyVault</PackageReleaseNotes>
+    <Version>5.1.0</Version>
+    <PackageReleaseNotes>Use new Azure SDK</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Eshopworld.DevOps</PackageId>
     <PackageIcon>icon.png</PackageIcon>
-    <Authors>Oisin Haken, Artur Zgodzinski</Authors>
+    <Authors>Oisin Haken, Artur Zgodzinski, Antonino Parisi</Authors>
     <Company>Eshopworld</Company>
     <Copyright>Eshopworld</Copyright>
     <PackageProjectUrl>https://github.com/eShopWorld/devops</PackageProjectUrl>
@@ -22,19 +22,19 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath=""/>
+    <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Core" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.1.1" />
+    <PackageReference Include="Eshopworld.Core" Version="4.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eshopworld.DevOps/EswDevOpsSdk.cs
+++ b/src/Eshopworld.DevOps/EswDevOpsSdk.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Azure.Identity;
 using JetBrains.Annotations;
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureKeyVault;
 
 namespace Eshopworld.DevOps
 {
@@ -74,13 +72,11 @@ namespace Eshopworld.DevOps
                 .AddEnvironmentVariables();
             var config = configBuilder.Build();
             var vaultUrl = config[KeyVaultUrlKey];
-            if (string.IsNullOrEmpty(vaultUrl))
+            if (string.IsNullOrWhiteSpace(vaultUrl))
                 return config;
 
             var kvConfigBuilder = CreateInitialConfigurationBuilder()
-                .AddAzureKeyVault(vaultUrl,
-                    new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)),
-                    new DefaultKeyVaultSecretManager())
+                .AddAzureKeyVault(new Uri(vaultUrl), new DefaultAzureCredential())
                 .AddEnvironmentVariables();
             return kvConfigBuilder.Build();
 

--- a/src/Tests/Eshopworld.DevOps.Tests/Eshopworld.DevOps.Tests.csproj
+++ b/src/Tests/Eshopworld.DevOps.Tests/Eshopworld.DevOps.Tests.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Use the new Azure SDK to load from KV. Addresses #61695 from the backlog.

This PR ditches Microsoft.Extensions.Configuration.AzureKeyVault because it is based on the old Azure SDK in favour of the new one as recommended here: https://www.nuget.org/packages/Microsoft.Azure.KeyVault/

Also replaces this PR: https://github.com/eShopWorld/devops/pull/26