### PR TITLE
AddKeyVaultSecrets method to allow mappings from secret name to a specified name

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,13 @@ public class Program
           // Load various config sources.
           builder.UseDefaultConfigs();
 
-		  var kvUrl = builder.GetValue<string>("KEYVAULT_URL");
-
           // Pass the name of the secrets you wish to load into the configuration builder.
-          builder.AddKeyVaultSecrets(new Uri(kvUrl), new Dictionary<string, string> {
+          builder.AddKeyVaultSecrets(new Dictionary<string, string> {
 				{ "TenandId","MyClass:MyTenantId" },
 				{ "SubscriptionId","MyClass:SubClass1:MySubId" },
 				{ "OtherSecretName","OtherSecretName" }
 			});
+			// Optional overload - you can pass the specific KV url if needed.
      }
      ...
 }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ public class Program
 
 ## Load secrets from Key Vault and map secret names to other config value names
 
-For convenience, you can choose to map your Key Vault secrets to other config names by passing an array of Key Value pairs (key is secret name, value is mapped name) instead of array of string (secret names), as follows:
+For convenience, you can choose to map your Key Vault secrets to other config names by passing a Dictionary (key is secret name, value is mapped name) instead of array of string (secret names), as follows:
 
 ```csharp
 public class Program
@@ -115,10 +115,11 @@ public class Program
 		  var kvUrl = builder.GetValue<string>("KEYVAULT_URL");
 
           // Pass the name of the secrets you wish to load into the configuration builder.
-          builder.AddKeyVaultSecrets(new Uri(kvUrl), 
-				new KeyValuePair<string, string>("TenandId","MyClass:MyTenantId"),
-				new KeyValuePair<string, string>("SubscriptionId","MyClass:SubClass1:MySubId"),
-				new KeyValuePair<string, string>("OtherSecretName","OtherSecretName"));
+          builder.AddKeyVaultSecrets(new Uri(kvUrl), new Dictionary<string, string> {
+				{ "TenandId","MyClass:MyTenantId" },
+				{ "SubscriptionId","MyClass:SubClass1:MySubId" },
+				{ "OtherSecretName","OtherSecretName" }
+			});
      }
      ...
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ AppSettings.json
 }
 ```
 
-
 ## Load individual secrets from multiple key vaults
 
 If you require settings to be loaded from multiple Key Vaults, it can be done in the following way:
@@ -99,6 +98,32 @@ public class Program
     ...
 }
 ```
+
+## Load secrets from Key Vault and map secret names to other config value names
+
+For convenience, you can choose to map your Key Vault secrets to other config names by passing an array of Key Value pairs (key is secret name, value is mapped name) instead of array of string (secret names), as follows:
+
+```csharp
+public class Program
+{
+     ...
+     public void ConfigureAppConfiguration(IConfigurationBuilder builder)
+     {
+          // Load various config sources.
+          builder.UseDefaultConfigs();
+
+		  var kvUrl = builder.GetValue<string>("KEYVAULT_URL");
+
+          // Pass the name of the secrets you wish to load into the configuration builder.
+          builder.AddKeyVaultSecrets(new Uri(kvUrl), 
+				new KeyValuePair<string, string>("TenandId","MyClass:MyTenantId"),
+				new KeyValuePair<string, string>("SubscriptionId","MyClass:SubClass1:MySubId"),
+				new KeyValuePair<string, string>("OtherSecretName","OtherSecretName"));
+     }
+     ...
+}
+```
+
 
 ## Using the loaded configuration
 

--- a/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
+++ b/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>5.1.6</Version>
-    <PackageReleaseNotes>Added BindSection for binding POCO properties to KeyVault secrets</PackageReleaseNotes>
+    <Version>5.1.7</Version>
+    <PackageReleaseNotes>Ability to map key vault secret names to any other given name.</PackageReleaseNotes>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Eshopworld.DevOps</PackageId>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
+++ b/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Extensions.Configuration
             if (keys == null || keys.Length == 0)
                 return builder;
 
-            var kvs = keys.Select(k => new KeyValuePair<string, string>(k, k)).ToArray();
+            var kvs = keys.ToDictionary(key => key, val => val);
             return AddKeyVaultSecrets(builder, vaultUrl, kvs, suppressKeyNotFoundError);
         }
 
@@ -234,18 +234,18 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="vaultUrl">Key vault url to connect to.</param>
-        /// <param name="keys">The list of keys values pairs to load and map to.</param>
+        /// <param name="keys">The dictionary of keys values to load (key) and map to (value).</param>
         /// <param name="suppressKeyNotFoundError">If [true], when a key is missing an invalid operation exception will be thrown. If [false], the
         /// error will be suppressed and it will just not add the key to the returned collection.</param>
         /// <returns>IConfigurationBuilder.</returns>
         /// <exception cref="ArgumentException">Vault url must be set</exception>
         /// <exception cref="InvalidOperationException">Problem occurred retrieving secrets from KeyVault using Managed Identity</exception>
-        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Uri vaultUrl, KeyValuePair<string,string>[] keys, bool suppressKeyNotFoundError = true)
+        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Uri vaultUrl, Dictionary<string,string> keys, bool suppressKeyNotFoundError = true)
         {
             if (vaultUrl == null)
                 throw new ArgumentNullException(nameof(vaultUrl), "Vault url must be set");
 
-            if (keys == null || keys.Length == 0)
+            if (keys == null || keys.Count == 0)
                 return builder;
 
             try

--- a/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
+++ b/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
@@ -208,6 +208,41 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
+        /// Adds the key vault secrets and maps them to a different key in IConfiguration.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="params">The parameters.</param>
+        /// <returns>IConfigurationBuilder.</returns>
+        /// <exception cref="InvalidOperationException">Vault url must be set, ensure \"{EswDevOpsSdk.KeyVaultUrlKey}\" or \"KeyVaultInstanceName\" have been set in config</exception>
+        /// <exception cref="InvalidOperationException">Vault url \"{vaultUrl}\" is invalid</exception>
+        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Dictionary<string, string> @params)
+        {
+            // Get the expected key vault url setting from the environment.
+            var vaultUrl = builder.GetValue<string>(EswDevOpsSdk.KeyVaultUrlKey);
+
+            if (string.IsNullOrEmpty(vaultUrl))
+            {
+                // If url was not set, look for an instance name and infer url.
+                var instanceName = builder.GetValue<string>("KeyVaultInstanceName");
+                vaultUrl = $"https://{instanceName}.vault.azure.net";
+            }
+
+            // Verify the key vault url is set.
+            if (string.IsNullOrEmpty(vaultUrl))
+            {
+                throw new InvalidOperationException($"Vault url must be set, ensure \"{EswDevOpsSdk.KeyVaultUrlKey}\" or \"KeyVaultInstanceName\" have been set in config");
+            }
+
+            // Verify the key vault url is a valid url.
+            if (!(Uri.TryCreate(vaultUrl, UriKind.Absolute, out var kvUri)))
+            {
+                throw new InvalidOperationException($"Vault url \"{vaultUrl}\" is invalid");
+            }
+
+            return AddKeyVaultSecrets(builder, kvUri, @params);
+        }
+
+        /// <summary>
         /// Adds the key vault secrets specified.  Uses Msi auth and builds the instance name on the fly.
         /// Needs config value "KeyVaultInstanceName" to work.
         /// </summary>

--- a/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
+++ b/src/Eshopworld.DevOps/Extensions/ConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable once CheckNamespace
+
 namespace Microsoft.Extensions.Configuration
 {
     using Azure.KeyVault;
@@ -64,7 +65,7 @@ namespace Microsoft.Extensions.Configuration
             PropertySecretMapping[] additionalPropertyMappings)
             where T : class, new()
         {
-            var propertyMappings = GetKeyVaultPropertyMappings<T>();
+            var propertyMappings = GetKeyVaultPropertyMappings<T>().ToArray();
 
             if (!propertyMappings.Any() && !additionalPropertyMappings.Any())
                 return;
@@ -218,32 +219,53 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>IConfigurationBuilder.</returns>
         /// <exception cref="ArgumentException">Vault url must be set</exception>
         /// <exception cref="InvalidOperationException">Problem occurred retrieving secrets from KeyVault using Managed Identity</exception>
-        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Uri vaultUrl, IEnumerable<string> keys, bool suppressKeyNotFoundError = true)
+        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Uri vaultUrl, string[] keys, bool suppressKeyNotFoundError = true)
+        {
+            if (keys == null || keys.Length == 0)
+                return builder;
+
+            var kvs = keys.Select(k => new KeyValuePair<string, string>(k, k)).ToArray();
+            return AddKeyVaultSecrets(builder, vaultUrl, kvs, suppressKeyNotFoundError);
+        }
+
+        /// <summary>
+        /// Adds the key vault secrets specified.  Uses Msi auth and builds the instance name on the fly.
+        /// Needs config value "KeyVaultInstanceName" to work.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="vaultUrl">Key vault url to connect to.</param>
+        /// <param name="keys">The list of keys values pairs to load and map to.</param>
+        /// <param name="suppressKeyNotFoundError">If [true], when a key is missing an invalid operation exception will be thrown. If [false], the
+        /// error will be suppressed and it will just not add the key to the returned collection.</param>
+        /// <returns>IConfigurationBuilder.</returns>
+        /// <exception cref="ArgumentException">Vault url must be set</exception>
+        /// <exception cref="InvalidOperationException">Problem occurred retrieving secrets from KeyVault using Managed Identity</exception>
+        public static IConfigurationBuilder AddKeyVaultSecrets(this IConfigurationBuilder builder, Uri vaultUrl, KeyValuePair<string,string>[] keys, bool suppressKeyNotFoundError = true)
         {
             if (vaultUrl == null)
                 throw new ArgumentNullException(nameof(vaultUrl), "Vault url must be set");
 
-            if (!keys.Any())
+            if (keys == null || keys.Length == 0)
                 return builder;
 
             try
             {
-                var vault = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback));
+                using var vault = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback));
                 var secrets = new List<KeyValuePair<string, string>>();
 
                 // Gather secrets from Key Vault, one by one.
-                foreach (var key in keys)
+                foreach (var pair in keys)
                 {
                     try
                     {
-                        var secret = vault.GetSecretAsync(vaultUrl.AbsoluteUri, key).ConfigureAwait(false).GetAwaiter().GetResult();
-                        secrets.Add(new KeyValuePair<string, string>(key, secret.Value));
+                        var secret = vault.GetSecretAsync(vaultUrl.AbsoluteUri, pair.Key).ConfigureAwait(false).GetAwaiter().GetResult();
+                        secrets.Add(new KeyValuePair<string, string>(pair.Value, secret.Value));
                     }
                     catch (KeyVaultErrorException e)
                         when (e.Response.StatusCode == HttpStatusCode.NotFound && suppressKeyNotFoundError)
                     {
                         // Do nothing if it fails to find the value.
-                        Console.WriteLine($"Failed to find key vault setting: {key}, exception: {e.Message}");
+                        Console.WriteLine($"Failed to find key vault setting: {pair}, exception: {e.Message}");
                     }
                 }
 

--- a/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
@@ -52,7 +52,7 @@ public class ConfigBuilderIntegrationTests
         IConfigurationBuilder builder = new ConfigurationBuilder();
 
         // Act
-        Action loadSettings = () => { builder.AddKeyVaultSecrets(null, new List<string> {"key1", "key2"}); };
+        Action loadSettings = () => { builder.AddKeyVaultSecrets(null, new [] {"key1", "key2"}); };
 
         // Assert
         loadSettings.Should().Throw<ArgumentNullException>();
@@ -94,6 +94,26 @@ public class ConfigBuilderIntegrationTests
 
         // Assert
         config.TryGetValue<object>("keyVaultItem", out var result).Should().BeTrue();
+        result.Should().NotBeNull();
+        result.Should().Be("keyVaultItemValue");
+    }
+
+    /// <summary>
+    /// Verify a real key in keyvault is added as expected and that it can be mapped to a config name that is different.
+    /// </summary>
+    [Fact, IsIntegration]
+    public void Test_KeyVault_Builder_AddKeyVaultSecrets_MapConfigName()
+    {
+        // Arrange - Principle needs "Set" permissions to run this.
+        IConfigurationBuilder builder = new ConfigurationBuilder();
+
+        // Act
+        builder.UseDefaultConfigs();
+        builder.AddKeyVaultSecrets("keyVaultItem", "MappedName");
+        var config = builder.Build();
+
+        // Assert
+        config.TryGetValue<object>("MappedName", out var result).Should().BeTrue();
         result.Should().NotBeNull();
         result.Should().Be("keyVaultItemValue");
     }

--- a/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
@@ -109,8 +109,10 @@ public class ConfigBuilderIntegrationTests
 
         // Act
         builder.UseDefaultConfigs();
-        var url = builder.GetValue<string>("KEYVAULT_URL");
-        builder.AddKeyVaultSecrets(new Uri(url), new Dictionary<string, string> { { "keyVaultItem", "MappedName"} });
+        builder.AddKeyVaultSecrets(new Dictionary<string, string>
+        {
+            { "keyVaultItem", "MappedName"}
+        });
         var config = builder.Build();
 
         // Assert

--- a/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
+++ b/src/Tests/Eshopworld.DevOps.Tests/ConfigBuilderIntegrationTests.cs
@@ -109,7 +109,8 @@ public class ConfigBuilderIntegrationTests
 
         // Act
         builder.UseDefaultConfigs();
-        builder.AddKeyVaultSecrets("keyVaultItem", "MappedName");
+        var url = builder.GetValue<string>("KEYVAULT_URL");
+        builder.AddKeyVaultSecrets(new Uri(url), new Dictionary<string, string> { { "keyVaultItem", "MappedName"} });
         var config = builder.Build();
 
         // Assert


### PR DESCRIPTION
Instead of using the secret name as the key in IConfiguration, a specific key can be specified using a KeyValue pair (key would be secret name, value would be the mapped name).