### PR TITLE
#83684 Downgrade Microsoft.Extensions.Configuration.AzureKeyVault

### DIFF
--- a/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
+++ b/src/Eshopworld.DevOps/Eshopworld.DevOps.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>5.1.7</Version>
-    <PackageReleaseNotes>Ability to map key vault secret names to any other given name.</PackageReleaseNotes>
+    <Version>5.1.8</Version>
+    <PackageReleaseNotes>Downgrade Microsoft.Extensions.Configuration.AzureKeyVault</PackageReleaseNotes>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Eshopworld.DevOps</PackageId>
     <PackageIcon>icon.png</PackageIcon>
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.7" />


### PR DESCRIPTION
Microsoft.Extensions.Configuration.AzureKeyVault and Microsoft.Azure.KeyVault fail to load from KV when the KV has too many secrets with any version higher than 2.2.0

Until we can upgrade to the new Azure SDK with MSI, we are downgrading those Microsoft.Extensions.Configuration.AzureKeyVault to v. 2.2.0 to address this issue.